### PR TITLE
chore: Make the hyperparameters configurable.

### DIFF
--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -27,7 +27,7 @@ Response likes following:
 Calling train API to train a new model:
 
 ```sh
-curl -X POST -H "Content-Type: application/json" http://127.0.0.1:5001/api/ai/train -d '{"dataset_id": "65ebd59f-7333-4e48-a595-4b95a540ed61", "desc": "this is a file"' "robot_id": "robot123" , "features": ["torque", "temperature", "current"]}'
+curl -X POST -H "Content-Type: application/json" http://127.0.0.1:5001/api/ai/train -d '{"dataset_id": "65ebd59f-7333-4e48-a595-4b95a540ed61", "desc": "this is a file", "robot_id": "robot123", "features": ["torque", "temperature", "current"], "hyperparameter": "{\"n_estimators\": 100, \"contamination\": 0.0000573, \"random_state\": 42}"}' 
 
 ```
 

--- a/sprout/routes.py
+++ b/sprout/routes.py
@@ -1,5 +1,6 @@
 import uuid
 import os
+import json
 from datetime import datetime
 
 from flask import Blueprint, request, jsonify
@@ -14,6 +15,7 @@ from sprout.isolation_forest.model import (
 from werkzeug.utils import secure_filename
 
 from sprout.storage.storage import MinIOModelStorage
+from sprout.isolation_forest.model_config import ModelConfig
 
 job_schema = JobSchema()
 jobs_schema = JobSchema(many=True)
@@ -285,6 +287,27 @@ def train():
     if not robot_id:
         return jsonify({"success": False, "error": "Missing robot_id parameter"}), 400
 
+    hyperparameter = data.get("hyperparameter")
+
+    if not hyperparameter:
+        hyperparameter = ModelConfig()
+
+    else:
+        try:
+            hyperparameter = ModelConfig.from_json(hyperparameter)
+        except json.JSONDecodeError as e:
+            return (
+                jsonify({"success": False, "error": f"Invalid JSON format: {str(e)}"}),
+                400,
+            )
+        except (TypeError, ValueError) as e:
+            return (
+                jsonify(
+                    {"success": False, "error": f"Invalid model parameters: {str(e)}"}
+                ),
+                400,
+            )
+
     dataser_model = Dataset.query.filter_by(
         dataset_id=dataset_id, robot_id=robot_id
     ).first()
@@ -303,7 +326,14 @@ def train():
     features = data.get("features")
 
     resource_file = file_path.replace(BUCKET, "")
-    result = train_isolation_forest_model(BUCKET_NAME, resource_file, features)
+    result = train_isolation_forest_model(
+        BUCKET_NAME,
+        resource_file,
+        features,
+        hyperparameter.n_estimators,
+        hyperparameter.contamination,
+        hyperparameter.random_state,
+    )
 
     model_filename = result["model_filename"]
     scaler_filename = result["scaler_filename"]
@@ -314,10 +344,7 @@ def train():
     scaler_hash = result["scaler_hash"]
     scores_size = result["scores_size"]
     scores_hash = result["scores_hash"]
-    # Only extract following params and save.
-    keys_to_extract = {"contamination", "n_estimators", "random_state"}
-    params = result["model"].get_params()
-    filtered_params = {key: params[key] for key in keys_to_extract}
+
     new_model = Model(
         name="IsolationForest",
         robot_id=robot_id,
@@ -328,7 +355,7 @@ def train():
     new_training = TrainingInfo(
         model=new_model,
         robot_id=new_model.robot_id,
-        hyperparameter=filtered_params,
+        hyperparameter=hyperparameter.to_json(),
         training_status="complete",
         created_at=datetime.now(),
     )


### PR DESCRIPTION
## Summary by Sourcery

Enable configurable isolation forest hyperparameters in the train endpoint by introducing a ModelConfig, handling input validation, and updating documentation.

New Features:
- Allow passing model hyperparameters (n_estimators, contamination, random_state) to the train API
- Persist provided hyperparameters in training records

Enhancements:
- Introduce a ModelConfig abstraction to handle default and user-supplied hyperparameters with validation
- Apply default hyperparameters when none are provided
- Add JSON decoding and value validation for the hyperparameter input

Documentation:
- Update USER_GUIDE example to include the hyperparameter field in the train API request