### PR TITLE
chore: Make the hyperparameters configurable.

### DIFF
--- a/doc/USER_GUIDE.md
+++ b/doc/USER_GUIDE.md
@@ -27,7 +27,7 @@ Response likes following:
 Calling train API to train a new model:
 
 ```sh
-curl -X POST -H "Content-Type: application/json" http://127.0.0.1:5001/api/ai/train -d '{"dataset_id": "65ebd59f-7333-4e48-a595-4b95a540ed61", "desc": "this is a file"' "robot_id": "robot123" , "features": ["torque", "temperature", "current"]}'
+curl -X POST -H "Content-Type: application/json" http://127.0.0.1:5001/api/ai/train -d '{"dataset_id": "65ebd59f-7333-4e48-a595-4b95a540ed61", "desc": "this is a file", "robot_id": "robot123", "features": ["torque", "temperature", "current"], "hyperparameter": "{\"n_estimators\": 100, \"contamination\": 0.0000573, \"random_state\": 42}"}' 
 
 ```
 

--- a/sprout/isolation_forest/model_config.py
+++ b/sprout/isolation_forest/model_config.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+import json
+
+
+@dataclass
+class ModelConfig:
+    """Configuration parameters for Isolation Forest model"""
+
+    n_estimators: int = 100
+    contamination: float = 0.0000573
+    random_state: int = 42
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "ModelConfig":
+        try:
+            data = json.loads(json_str)
+            return cls(**data)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON: {str(e)}") from e
+
+    def to_json(self):
+        return json.dumps(self.__dict__)


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable Isolation Forest hyperparameters via a new ModelConfig dataclass and update the training endpoint and documentation to accept custom settings.

New Features:
- Allow clients to supply custom Isolation Forest hyperparameters through the train API.

Enhancements:
- Add ModelConfig dataclass with JSON (de)serialization and default values for hyperparameters.
- Refactor train endpoint to parse the hyperparameter JSON, apply its values to the model training call, and persist the configuration.
- Fallback to default ModelConfig when no hyperparameter is provided.

Documentation:
- Update the user guide example to include the new hyperparameter field in the API request.