### PR TITLE
Use flask_restx to replace flask_restful which has Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ docker-compose -f compose-minio.yaml down -v
 
 ## User guide
 [User Guide](doc/USER_GUIDE.md)
+
+Swagger UI is available at /docs, for example you can open http://127.0.0.1:5001/docs and try REST APIs there.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ flask
 flask_sqlalchemy
 flask_marshmallow
 flask_migrate
-Flask-RESTful
+flask-restx
 marshmallow-sqlalchemy
 celery[redis,redisbeat]
 pytest

--- a/sprout/__init__.py
+++ b/sprout/__init__.py
@@ -1,7 +1,8 @@
 from flask import Flask
 from flask_marshmallow import Marshmallow
 from flask_migrate import Migrate
-from flask_restful import Api
+from flask_restx import Api
+
 from flask_sqlalchemy import SQLAlchemy
 from sprout.config import Config
 from sprout.extensions import db, ma, make_celery
@@ -26,7 +27,14 @@ def create_app():
     app.register_blueprint(job_bp, url_prefix="/api")
     app.register_blueprint(ai_bp, url_prefix="/api")
 
-    api = Api(app)
+    # Initialize Flask-RESTx API
+    api = Api(
+        app,
+        version="0.1",
+        title="Project Sprout's API",
+        description="Sprout APIs",
+        doc="/docs"
+    )
 
     # Register endpoints
     api.add_resource(CaseListResource, '/api/cases')

--- a/sprout/resources/case.py
+++ b/sprout/resources/case.py
@@ -1,4 +1,4 @@
-from flask_restful import abort, Resource, reqparse
+from flask_restx import abort, reqparse, Namespace, Resource
 from sprout import db
 from sprout.models import Case
 
@@ -11,6 +11,11 @@ case_parser.add_argument("case_type", type=str)
 case_parser.add_argument("model_name", type=str)
 case_parser.add_argument("description", type=str)
 
+# Create a namespace for /api
+api_ns = Namespace("api", description="API operations")
+
+
+@api_ns.route("/cases")
 class CaseListResource(Resource):
     def get(self):
         cases = Case.query.all()
@@ -23,6 +28,7 @@ class CaseListResource(Resource):
         db.session.commit()
         return new_case.to_dict(), 201
 
+@api_ns.route("cases/<string:case_id>")
 class CaseResource(Resource):
     def get(self, case_id):
         case = Case.query.get(case_id)


### PR DESCRIPTION
## Summary by Sourcery

Replace Flask-RESTful with Flask-RESTx and enable built-in Swagger UI for interactive API documentation.

New Features:
- Introduce Swagger UI at /docs for interactive API exploration

Enhancements:
- Initialize Flask-RESTx Api with version, title, description, and custom docs endpoint
- Define an API namespace for routing and update resource decorators accordingly

Build:
- Swap Flask-RESTful dependency for flask-restx in requirements.txt

Documentation:
- Update README to reference the Swagger UI endpoint