### PR TITLE
Refactor Job API with flask_restx

### DIFF
--- a/sprout/__init__.py
+++ b/sprout/__init__.py
@@ -1,13 +1,12 @@
 from flask import Flask
-from flask_marshmallow import Marshmallow
 from flask_migrate import Migrate
 from flask_restx import Api
 
-from flask_sqlalchemy import SQLAlchemy
 from sprout.config import Config
 from sprout.extensions import db, ma, make_celery
-from sprout.resources.case import CaseListResource, CaseResource
-from sprout.routes import ai_bp, job_bp
+from sprout.resources.case import CaseListResource, CaseResource  # noqa: F401
+from sprout.resources.job import JobListResource, JobResource  # noqa: F401
+from sprout.routes import ai_bp, api_ns
 
 
 def create_app():
@@ -24,7 +23,6 @@ def create_app():
     migrate.init_app(app, db)
 
     # Register blueprints and routes
-    app.register_blueprint(job_bp, url_prefix="/api")
     app.register_blueprint(ai_bp, url_prefix="/api")
 
     # Initialize Flask-RESTx API
@@ -36,9 +34,8 @@ def create_app():
         doc="/docs"
     )
 
-    # Register endpoints
-    api.add_resource(CaseListResource, '/api/cases')
-    api.add_resource(CaseResource, '/api/cases/<string:case_id>')
+    # Register the /api namespace
+    api.add_namespace(api_ns)
 
     with app.app_context():
         db.create_all()

--- a/sprout/resources/case.py
+++ b/sprout/resources/case.py
@@ -1,7 +1,7 @@
-from flask_restx import abort, reqparse, Namespace, Resource
+from flask_restx import abort, reqparse, Resource
 from sprout import db
 from sprout.models import Case
-
+from sprout.routes import api_ns
 
 # Parser for incoming POST/PUT data
 case_parser = reqparse.RequestParser()
@@ -10,9 +10,6 @@ case_parser.add_argument("robot_id", type=str, required=True, help="robot_id is 
 case_parser.add_argument("case_type", type=str)
 case_parser.add_argument("model_name", type=str)
 case_parser.add_argument("description", type=str)
-
-# Create a namespace for /api
-api_ns = Namespace("api", description="API operations")
 
 
 @api_ns.route("/cases")
@@ -28,7 +25,7 @@ class CaseListResource(Resource):
         db.session.commit()
         return new_case.to_dict(), 201
 
-@api_ns.route("cases/<string:case_id>")
+@api_ns.route("/cases/<string:case_id>")
 class CaseResource(Resource):
     def get(self, case_id):
         case = Case.query.get(case_id)

--- a/sprout/resources/job.py
+++ b/sprout/resources/job.py
@@ -1,0 +1,71 @@
+import time
+
+from flask_restx import abort, reqparse, Resource
+from sprout import db
+from sprout.models import Job
+from sprout.routes import api_ns
+
+
+# Parser for incoming POST data
+job_post_parser = reqparse.RequestParser()
+job_post_parser.add_argument("params", type=dict, required=False, help="Params must be a dictionary")
+
+# Parser for incoming PUT data
+job_put_parser = reqparse.RequestParser()
+job_put_parser.add_argument("job_id", type=str, required=True, help="Job ID is required")
+job_put_parser.add_argument("params", type=dict, required=False, help="Params must be a dictionary")
+
+
+@api_ns.route("/jobs")
+class JobListResource(Resource):
+    def get(self):
+        """Get all jobs"""
+        jobs = Job.query.all()
+        return [job.to_dict() for job in jobs], 200
+
+    def post(self):
+        """Create a new job"""
+        from sprout.celery_worker import (
+            execute_job,
+        )  # Import here to prevent circular import
+
+        args = job_post_parser.parse_args()
+        job_id = f"job_{int(time.time())}"
+        new_job = Job(job_id=job_id, **args)
+        db.session.add(new_job)
+        db.session.commit()
+
+        # Trigger Celery task
+        execute_job.apply_async(args=[job_id, args])
+
+        return new_job.to_dict(), 201
+
+
+@api_ns.route("/jobs/<int:job_id>")
+class JobResource(Resource):
+    def get(self, job_id):
+        """Get a single job by ID"""
+        job = Job.query.get(job_id)
+        if not job:
+            abort(404, message="Job not found")
+        return job.to_dict(), 200
+
+    def put(self, job_id):
+        """Update a job"""
+        job = Job.query.get(job_id)
+        if not job:
+            abort(404, message="Job not found")
+        args = job_put_parser.parse_args()
+        for key, value in args.items():
+            setattr(job, key, value)
+        db.session.commit()
+        return job.to_dict(), 200
+
+    def delete(self, job_id):
+        """Delete a job"""
+        job = Job.query.get(job_id)
+        if not job:
+            abort(404, message="Job not found")
+        db.session.delete(job)
+        db.session.commit()
+        return {"message": "Deleted successfully"}, 200


### PR DESCRIPTION
## Summary by Sourcery

Refactor the Job API to use Flask-RESTx namespaces and Resource classes, consolidating job and case endpoints under a single API namespace and removing the previous Blueprint-based routes and Marshmallow schemas.

Enhancements:
- Replace manual job routes with Flask-RESTx Resource classes under the api namespace
- Move job CRUD operations into sprout/resources/job.py using reqparse and model.to_dict
- Unify case endpoints to use the shared api namespace instead of a separate Namespace instance
- Remove Marshmallow schemas and the job blueprint in favor of Flask-RESTx integration